### PR TITLE
Notify user of dependent `search_engine` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Run the following from your installation root folder
 
 Or go to Setup -> Extensions in admin interface and click the "Regenerate autoload arrays" button
 
+### Update parameters.yml
+
+Ensure that the parameter `search_engine` exists by adding it to `parameters.yml`
+
+```yml
+search_engine: solr
+```
+
 Searching for content instead of locations
 ------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ Run the following from your installation root folder
 
 Or go to Setup -> Extensions in admin interface and click the "Regenerate autoload arrays" button
 
-### Update parameters.yml
+### Ensure parameters.yml has required parameters
 
-Ensure that the parameter `search_engine` exists by adding it to `parameters.yml`
+Check if you have the `search_engine` parameter in your `parameters.yml` file. Set it to either `solr` or `legacy` if it is not yet set.
 
 ```yml
+# One of `legacy` or `solr`
 search_engine: solr
 ```
 


### PR DESCRIPTION
The `search_engine` doesn't exist by default and is required for the new search engine to function.
