### PR TITLE
Fix indexing when restoring Content from trash

### DIFF
--- a/search/plugins/ezplatformsearch/ezplatformsearch.php
+++ b/search/plugins/ezplatformsearch/ezplatformsearch.php
@@ -81,6 +81,17 @@ class eZPlatformSearch implements ezpSearchEngine
 
         try
         {
+            // If the method is called for restoring from trash we'll be inside a transaction,
+            // meaning created Location(s) will not be visible outside of it.
+            // We check that Content's Locations are visible from the new stack, if not Content
+            // will be registered for indexing.
+            foreach ( $contentObject->assignedNodes() as $node )
+            {
+                $this->persistenceHandler->locationHandler()->load(
+                    $node->attribute( 'node_id' )
+                );
+            }
+
             $content = $this->persistenceHandler->contentHandler()->load(
                 (int)$contentObject->attribute( 'id' ),
                 (int)$contentObject->attribute( 'current_version' )


### PR DESCRIPTION
Fixes https://github.com/netgen/ezplatformsearch/issues/8

During restoring Content from trash, `addObject()` method will be called from inside of transaction (see content/publish operation [here](https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/content/restore.php#L87-L168)).
That means Search Engine in new stack will not have restored Location(s) available for indexing.

This fix applies the same approach as in https://github.com/netgen/ezplatformsearch/pull/4.
All Content's Locations are checked for existence from the new stack. In case when a Location is missing, instead of immediate indexing Content will be registered for indexing with pending actions.
