### PR TITLE
Perform commit when removing from index

### DIFF
--- a/search/plugins/ezplatformsearch/ezplatformsearch.php
+++ b/search/plugins/ezplatformsearch/ezplatformsearch.php
@@ -28,6 +28,11 @@ class eZPlatformSearch implements ezpSearchEngine
     protected $searchEngine;
 
     /**
+     * @var \eZINI
+     */
+    protected $iniConfig;
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -38,6 +43,8 @@ class eZPlatformSearch implements ezpSearchEngine
         $this->persistenceHandler = $serviceContainer->get( 'ezpublish.api.persistence_handler' );
         $this->repository = $serviceContainer->get( 'ezpublish.api.repository' );
         $this->searchEngine = $serviceContainer->getParameter( 'search_engine' );
+
+        $this->iniConfig = eZINI::instance( 'ezplatformsearch.ini' );
     }
 
     /**
@@ -138,6 +145,15 @@ class eZPlatformSearch implements ezpSearchEngine
      */
     public function removeObjectById( $contentObjectId, $commit = null )
     {
+        if ( !isset( $commit ) && ( $this->iniConfig->variable( 'IndexOptions', 'DisableDeleteCommits' ) === 'true' ) )
+        {
+            $commit = false;
+        }
+        elseif ( !isset( $commit ) )
+        {
+            $commit = true;
+        }
+
         // Indexing is not implemented in eZ Publish 5 legacy search engine
         if ( $this->searchEngine == 'legacy' )
         {
@@ -270,8 +286,7 @@ class eZPlatformSearch implements ezpSearchEngine
         $query->limit = isset( $params['SearchLimit'] ) ? (int)$params['SearchLimit'] : 10;
         $query->offset = isset( $params['SearchOffset'] ) ? (int)$params['SearchOffset'] : 0;
 
-        $useLocationSearch = eZINI::instance( 'ezplatformsearch.ini' )
-            ->variable( 'SearchSettings', 'UseLocationSearch' ) === 'true';
+        $useLocationSearch = $this->iniConfig->variable( 'SearchSettings', 'UseLocationSearch' ) === 'true';
 
         if ( $useLocationSearch )
         {

--- a/settings/ezplatformsearch.ini
+++ b/settings/ezplatformsearch.ini
@@ -2,3 +2,9 @@
 
 [SearchSettings]
 UseLocationSearch=true
+
+[IndexOptions]
+# DisableDeleteCommits=true|false
+# Be careful with this option, deleted objects may still show up in search results, leading to (fatal) errors
+# Make sure you have a frequent commit cronjob enabled if you set it to true to minimize errors
+DisableDeleteCommits=false


### PR DESCRIPTION
Fixes https://github.com/netgen/ezplatformsearch/issues/7

By default, commit will not be performed when removing data from index. Also, it is not possible to configure this behavior.

This implements ini configuration option to control committing when removing data from index.
Additionally, default behavior is changed so that commit is performed.

This is in line with how ezfind behaves, see:
- https://github.com/ezsystems/ezfind/blob/master/search/plugins/ezsolr/ezsolr.php#L892-L899
- https://github.com/ezsystems/ezfind/blob/master/settings/ezfind.ini#L191-L194
