### PR TITLE
Full text fix

### DIFF
--- a/search/plugins/ezplatformsearch/ezplatformsearch.php
+++ b/search/plugins/ezplatformsearch/ezplatformsearch.php
@@ -286,7 +286,7 @@ class eZPlatformSearch implements ezpSearchEngine
             $query->query = new Criterion\FullText( $searchText );
         }
 
-        if( !empty( $criteria ) )
+        if ( !empty( $criteria ) )
         {
             $query->filter = new Criterion\LogicalAnd( $criteria );
         }
@@ -317,12 +317,11 @@ class eZPlatformSearch implements ezpSearchEngine
         if ( !empty( $nodeIds ) )
         {
             $resultNodes = eZContentObjectTreeNode::fetch( $nodeIds );
-
-            if( !is_array( $resultNodes ) )
+            if ( $resultNodes instanceof eZContentObjectTreeNode )
             {
                 $resultNodes = array ( $resultNodes );
             }
-            else
+            elseif ( is_array( $resultNodes ) )
             {
                 $nodeIds = array_flip( $nodeIds );
 

--- a/search/plugins/ezplatformsearch/ezplatformsearch.php
+++ b/search/plugins/ezplatformsearch/ezplatformsearch.php
@@ -315,14 +315,18 @@ class eZPlatformSearch implements ezpSearchEngine
         $resultNodes = array();
         if ( !empty( $nodeIds ) )
         {
+            $resultNodes = array_fill_keys($nodeIds, '');
+
             $nodes = eZContentObjectTreeNode::fetch( $nodeIds );
             if ( $nodes instanceof eZContentObjectTreeNode )
             {
-                $resultNodes = array( $nodes );
+                $resultNodes[$nodes->attribute('node_id')] = $nodes;
             }
             else if ( is_array( $nodes ) )
             {
-                $resultNodes = $nodes;
+                foreach($nodes as $node){
+                    $resultNodes[$node->attribute('node_id')] = $node;
+                }
             }
         }
 

--- a/search/plugins/ezplatformsearch/ezplatformsearch.php
+++ b/search/plugins/ezplatformsearch/ezplatformsearch.php
@@ -283,10 +283,12 @@ class eZPlatformSearch implements ezpSearchEngine
 
         if ( $doFullText )
         {
-            $criteria[] = new Criterion\FullText( $searchText );
+            $query->query = new Criterion\FullText( $searchText );
         }
 
-        $query->query = new Criterion\LogicalAnd( $criteria );
+        if(!empty($criteria)) {
+            $query->filter = new Criterion\LogicalAnd( $criteria );
+        }
 
         $query->limit = isset( $params['SearchLimit'] ) ? (int)$params['SearchLimit'] : 10;
         $query->offset = isset( $params['SearchOffset'] ) ? (int)$params['SearchOffset'] : 0;

--- a/search/plugins/ezplatformsearch/ezplatformsearch.php
+++ b/search/plugins/ezplatformsearch/ezplatformsearch.php
@@ -286,7 +286,8 @@ class eZPlatformSearch implements ezpSearchEngine
             $query->query = new Criterion\FullText( $searchText );
         }
 
-        if(!empty($criteria)) {
+        if( !empty( $criteria ) )
+        {
             $query->filter = new Criterion\LogicalAnd( $criteria );
         }
 
@@ -315,18 +316,28 @@ class eZPlatformSearch implements ezpSearchEngine
         $resultNodes = array();
         if ( !empty( $nodeIds ) )
         {
-            $resultNodes = array_fill_keys($nodeIds, '');
+            $resultNodes = eZContentObjectTreeNode::fetch( $nodeIds );
 
-            $nodes = eZContentObjectTreeNode::fetch( $nodeIds );
-            if ( $nodes instanceof eZContentObjectTreeNode )
+            if( !is_array( $resultNodes ) )
             {
-                $resultNodes[$nodes->attribute('node_id')] = $nodes;
+                $resultNodes = array ( $resultNodes );
             }
-            else if ( is_array( $nodes ) )
+            else
             {
-                foreach($nodes as $node){
-                    $resultNodes[$node->attribute('node_id')] = $node;
-                }
+                $nodeIds = array_flip( $nodeIds );
+
+                usort(
+                    $resultNodes,
+                    function ( eZContentObjectTreeNode $node1, eZContentObjectTreeNode $node2 ) use ( $nodeIds )
+                    {
+                        if ( $node1->attribute( 'node_id' ) === $node2->attribute( 'node_id' ) )
+                        {
+                            return 0;
+                        }
+
+                        return ( $nodeIds[$node1->attribute( 'node_id' )] < $nodeIds[$node2->attribute( 'node_id' )] ) ? -1 : 1;
+                    }
+                );
             }
         }
 


### PR DESCRIPTION
This pull requests fixes two problems with the search results:
1. Passing any criteria other than a FullText to a query seriously impacts the search result scores - this can lead to a situations where you want to find specific object by an exact name, and the object you are looking for won't appear in the top 10 results, sometimes not even on the first 5 result pages :(

2. When performing an eZContentObjectTreeNode::fetch with the list of node IDs, you will get results ordered by whatever sorting the database is using for this table (probably by node ID in ascending order). Thus we need to sort the fetch results in original order from the list of node IDs we passed to the fetch method.