### PR TITLE
Add IndexOptions/NeedRemoveWithUpdate configuration option

### DIFF
--- a/search/plugins/ezplatformsearch/ezplatformsearch.php
+++ b/search/plugins/ezplatformsearch/ezplatformsearch.php
@@ -58,7 +58,7 @@ class eZPlatformSearch implements ezpSearchEngine
      */
     public function needRemoveWithUpdate()
     {
-        return true;
+        return $this->iniConfig->variable( 'IndexOptions', 'NeedRemoveWithUpdate' ) === 'true';
     }
 
     /**

--- a/settings/ezplatformsearch.ini
+++ b/settings/ezplatformsearch.ini
@@ -8,3 +8,6 @@ UseLocationSearch=true
 # Be careful with this option, deleted objects may still show up in search results, leading to (fatal) errors
 # Make sure you have a frequent commit cronjob enabled if you set it to true to minimize errors
 DisableDeleteCommits=false
+# NeedRemoveWithUpdate=true|false
+# Whether calling removeObject() is required when updating an object.
+NeedRemoveWithUpdate=true


### PR DESCRIPTION
Search engine interface contains method `needRemoveWithUpdate()` to decide if the object needs to be removed before it's updated. By default it was returning `true`, causing documents to disappear from index in come cases (for example adding a Location), until the cronjob re-indexes it from the added entry in `ezpending_actions` table.

The behavior was initially copied from default implementation, but should not be really needed for integration with Solr search engine. This PR adds `IndexOptions/NeedRemoveWithUpdate` configuration option, by default configured to `true` in order to keep the existing behavior.