### PR TITLE
Switch from ezpublish.api.persistence_handler to ezpublish.api.storagine

### DIFF
--- a/search/plugins/ezplatformsearch/ezplatformsearch.php
+++ b/search/plugins/ezplatformsearch/ezplatformsearch.php
@@ -35,7 +35,7 @@ class eZPlatformSearch implements ezpSearchEngine
         $serviceContainer = ezpKernel::instance()->getServiceContainer();
 
         $this->searchHandler = $serviceContainer->get( 'ezpublish.spi.search' );
-        $this->persistenceHandler = $serviceContainer->get( 'ezpublish.api.persistence_handler' );
+        $this->persistenceHandler = $serviceContainer->get( 'ezpublish.api.storage_engine' );
         $this->repository = $serviceContainer->get( 'ezpublish.api.repository' );
 
         $this->iniConfig = eZINI::instance( 'ezplatformsearch.ini' );


### PR DESCRIPTION
Switch from `ezpublish.api.persistence_handler` to `ezpublish.api.storage_engine` in order to avoid unwanted side effects when indexing.
An example is when having a `ezbinaryfile` field. When loading the field value, `\eZ\Publish\Core\MVC\Symfony\FieldType\BinaryBase\ContentDownloadUrlGenerator` will be called in order to generate value for `BinaryFile\Value::$uri`. Problem is that using ezplatformsearch, the URI will be generated using admin siteaccess and cached as is in persistence cache.

This patch does not completely fix the problem, which is at the fieldtype level but using `ezpublish.api.storage_engine` workarounds the issue and avoids it to repeat with similar field types.